### PR TITLE
Rework track queueing and resolving

### DIFF
--- a/Common/Music/Resolvers/IMusicResolver.cs
+++ b/Common/Music/Resolvers/IMusicResolver.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using Lavalink4NET.Rest;
 using Lavalink4NET.Rest.Entities.Tracks;
@@ -10,7 +11,8 @@ public interface IMusicResolver
 {
     bool IsAvailable { get; }
     bool CanResolve(string query);
-    ValueTask<TrackLoadResult> Resolve(ITrackManager cluster, LavalinkApiResolutionScope resolutionScope, string query);
+    ValueTask<MusicResolveResult> Resolve(ITrackManager cluster, LavalinkApiResolutionScope resolutionScope,
+        string query, CancellationToken cancellationToken);
     bool CanEncodeTrack(LavalinkTrack track);
     ValueTask<IEncodedTrack> EncodeTrack(LavalinkTrack track);
     bool CanDecodeTrack(IEncodedTrack track);

--- a/Common/Music/Resolvers/Lavalink/LavalinkMusicResolver.cs
+++ b/Common/Music/Resolvers/Lavalink/LavalinkMusicResolver.cs
@@ -18,15 +18,14 @@ public sealed class LavalinkMusicResolver : MusicResolverBase<LavalinkTrack, Lav
         return true;
     }
 
-    public override async ValueTask<TrackLoadResult> Resolve(ITrackManager cluster,
-        LavalinkApiResolutionScope resolutionScope, string query)
+    public override async ValueTask<MusicResolveResult> Resolve(ITrackManager cluster,
+        LavalinkApiResolutionScope resolutionScope, string query, CancellationToken cancellationToken)
     {
         TrackSearchMode trackSearchMode;
         if (Utilities.IsValidUrl(query))
-            return await cluster.LoadTracksAsync(query, TrackSearchMode.None, resolutionScope);
+            return await cluster.LoadTracksAsync(query, TrackSearchMode.None, resolutionScope, cancellationToken);
 
-        var track = await cluster.LoadTrackAsync(query, TrackSearchMode.YouTube, resolutionScope,
-            CancellationToken.None);
+        var track = await cluster.LoadTrackAsync(query, TrackSearchMode.YouTube, resolutionScope, cancellationToken);
         return track is not null
             ? TrackLoadResult.CreateTrack(track)
             : TrackLoadResult.CreateEmpty();

--- a/Common/Music/Resolvers/MusicResolveResult.cs
+++ b/Common/Music/Resolvers/MusicResolveResult.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text.Json;
+using Lavalink4NET.Rest.Entities.Tracks;
+using Lavalink4NET.Tracks;
+using Tyrrrz.Extensions;
+
+namespace Common.Music.Resolvers;
+
+public class MusicResolveResult
+{
+    private static readonly IAsyncEnumerable<LavalinkTrack> EmptyLavalinkTracks =
+        Array.Empty<LavalinkTrack>().ToAsyncEnumerable();
+
+    public MusicResolveResult(IReadOnlyList<LavalinkTrack> tracks, PlaylistInformation? playlistInformation = null) :
+        this(tracks)
+    {
+        Playlist = playlistInformation;
+    }
+
+    public MusicResolveResult(IReadOnlyList<LavalinkTrack> tracks)
+    {
+        Tracks = tracks.ToAsyncEnumerable();
+    }
+
+    public MusicResolveResult(IAsyncEnumerable<LavalinkTrack> tracks, string? playlistName = null) :
+        this(tracks)
+    {
+        if (playlistName != null)
+            Playlist = new PlaylistInformation(playlistName, null, ImmutableDictionary<string, JsonElement>.Empty);
+    }
+
+    public MusicResolveResult(IAsyncEnumerable<LavalinkTrack> tracks)
+    {
+        Tracks = tracks;
+    }
+
+    public MusicResolveResult(TrackException? exception)
+    {
+        Tracks = EmptyLavalinkTracks;
+        Exception = exception;
+    }
+
+    public IAsyncEnumerable<LavalinkTrack> Tracks { get; init; }
+    public PlaylistInformation? Playlist { get; init; }
+    public TrackException? Exception { get; init; }
+
+    public static implicit operator MusicResolveResult(TrackLoadResult trackLoadResult)
+    {
+        return trackLoadResult.IsFailed
+            ? new MusicResolveResult(trackLoadResult.Exception)
+            : new MusicResolveResult(trackLoadResult.Tracks, trackLoadResult.Playlist);
+    }
+}

--- a/Common/Music/Resolvers/MusicResolverBase.cs
+++ b/Common/Music/Resolvers/MusicResolverBase.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Lavalink4NET.Rest;
 using Lavalink4NET.Rest.Entities.Tracks;
@@ -14,8 +15,8 @@ public abstract class MusicResolverBase<TTrack, TEncodedTrack> : IMusicResolver
     public abstract bool IsAvailable { get; }
     public abstract bool CanResolve(string query);
 
-    public abstract ValueTask<TrackLoadResult> Resolve(ITrackManager cluster,
-        LavalinkApiResolutionScope resolutionScope, string query);
+    public abstract ValueTask<MusicResolveResult> Resolve(ITrackManager cluster,
+        LavalinkApiResolutionScope resolutionScope, string query, CancellationToken cancellationToken);
 
     public bool CanEncodeTrack(LavalinkTrack track)
     {

--- a/Common/Music/Resolvers/MusicResolverService.cs
+++ b/Common/Music/Resolvers/MusicResolverService.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Common.Music.Tracks;
 using Lavalink4NET.Protocol.Models;
@@ -13,7 +14,7 @@ namespace Common.Music.Resolvers;
 
 public class MusicResolverService(IEnumerable<IMusicResolver> musicResolvers, ITrackManager cluster)
 {
-    public async Task<TrackLoadResult> ResolveTracks(LavalinkApiResolutionScope resolutionScope, string query)
+    public async Task<MusicResolveResult> ResolveTracks(LavalinkApiResolutionScope resolutionScope, string query, CancellationToken cancellationToken)
     {
         foreach (var resolver in musicResolvers)
         {
@@ -25,11 +26,11 @@ public class MusicResolverService(IEnumerable<IMusicResolver> musicResolvers, IT
 
             if (!resolver.IsAvailable)
             {
-                return TrackLoadResult.CreateError(new TrackException(ExceptionSeverity.Fault,
+                return new MusicResolveResult(new TrackException(ExceptionSeverity.Fault,
                     "Target resolving service unavailable", null));
             }
 
-            return await resolver.Resolve(cluster, resolutionScope, query);
+            return await resolver.Resolve(cluster, resolutionScope, query, cancellationToken);
         }
 
         throw new InvalidOperationException("No resolvers to fulfil request");

--- a/Enliven/Commands/Music/PlayCommand.cs
+++ b/Enliven/Commands/Music/PlayCommand.cs
@@ -29,7 +29,7 @@ public sealed class PlayCommand : MusicModuleBase
     [Command("play", RunMode = RunMode.Async)]
     [Alias("p")]
     [Summary("play0s")]
-    public async Task Play([Remainder] [SlashCommandOptional(false)] [Summary("play0_0s")] string? query = null)
+    public async Task Play([Remainder] [SlashCommandOptional] [Summary("play0_0s")] string? query = null)
     {
         await PlayInternal(query);
     }
@@ -38,19 +38,19 @@ public sealed class PlayCommand : MusicModuleBase
     [Command("playnext", RunMode = RunMode.Async)]
     [Alias("pn")]
     [Summary("playnext0s")]
-    public async Task PlayNext([Remainder] [SlashCommandOptional(false)] [Summary("play0_0s")] string? query = null)
+    public async Task PlayNext([Remainder] [SlashCommandOptional] [Summary("play0_0s")] string? query = null)
     {
-        await PlayInternal(query, Player.Playlist.Count == 0 ? -1 : Player.CurrentTrackIndex + 1);
+        await PlayInternal(query, Player.Playlist.Count == 0 ? null : Player.CurrentTrackIndex + 1);
     }
 
-    private async Task PlayInternal(string? query, int position = -1)
+    private async Task PlayInternal(string? query, int? position = null)
     {
         var messageInvoker = (Context as TextCommandsModuleContext)?.Message;
         var queries = await GetMusicQueries(messageInvoker, query.IsBlank(""));
         var mainPlayerDisplay = await GetMainPlayerDisplay();
         if (queries.Count != 0)
         {
-            await StartResolvingInternal(query, position, mainPlayerDisplay, queries);
+            await StartResolvingInternal(position, mainPlayerDisplay, queries);
             return;
         }
 
@@ -64,8 +64,7 @@ public sealed class PlayCommand : MusicModuleBase
         }
     }
 
-    private async Task StartResolvingInternal(string? query, int position, EmbedPlayerDisplay mainPlayerDisplay,
-        IEnumerable<string> queries)
+    private async Task StartResolvingInternal(int? position, EmbedPlayerDisplay mainPlayerDisplay, IEnumerable<string> queries)
     {
         if (Context.NeedResponse)
             await mainPlayerDisplay.ResendControlMessageWithOverride(OverrideSendingControlMessage, false);

--- a/Enliven/DiscordRelated/Music/EmbedPlayerDisplay.cs
+++ b/Enliven/DiscordRelated/Music/EmbedPlayerDisplay.cs
@@ -282,6 +282,12 @@ public class EmbedPlayerDisplay : PlayerDisplayBase
         );
 
         UpdateNode();
+        UpdateQueue();
+        UpdateEffects();
+        UpdateParameters();
+        UpdateMessageComponents();
+        UpdateTrackInfo();
+        UpdateProgress();
         await ControlMessageResend();
         return;
         

--- a/Enliven/Music/Vk/VkMusicResolver.cs
+++ b/Enliven/Music/Vk/VkMusicResolver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Common.Config;
 using Common.Music.Resolvers;
@@ -58,8 +59,8 @@ public class VkMusicResolver : MusicResolverBase<VkLavalinkTrack, VkTrackData>
 
     public override bool CanResolve(string query) => new VkUrl(query).IsValid;
 
-    public override async ValueTask<TrackLoadResult> Resolve(ITrackManager cluster,
-        LavalinkApiResolutionScope resolutionScope, string query)
+    public override async ValueTask<MusicResolveResult> Resolve(ITrackManager cluster,
+        LavalinkApiResolutionScope resolutionScope, string query, CancellationToken cancellationToken)
     {
         var vkUrl = new VkUrl(query);
         var audios = await vkUrl.Resolve(_vkApi);

--- a/Enliven/Music/Yandex/YandexMusicResolver.cs
+++ b/Enliven/Music/Yandex/YandexMusicResolver.cs
@@ -2,6 +2,7 @@
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using System.Threading.Tasks;
 using Common;
 using Common.Music.Resolvers;
@@ -24,9 +25,9 @@ public class YandexMusicResolver : MusicResolverBase<YandexLavalinkTrack, Yandex
     public override bool IsAvailable => true;
     public override bool CanResolve(string query) => _musicMainResolver.CanResolveQuery(query, false);
 
-    public override async ValueTask<TrackLoadResult> Resolve(ITrackManager cluster,
+    public override async ValueTask<MusicResolveResult> Resolve(ITrackManager cluster,
         LavalinkApiResolutionScope resolutionScope,
-        string query)
+        string query, CancellationToken cancellationToken)
     {
         var yandexMusicSearchResult = await _musicMainResolver.ResolveQuery(query, true, false);
         if (yandexMusicSearchResult == null) return TrackLoadResult.CreateEmpty();


### PR DESCRIPTION
- add support for selected tracks in playlist 
- add lazy loading tracks
- one by one loading for spotify/deezer
- Fixes the track switching on display, suppress nullable warnings
- Update all the embed data after changing player
